### PR TITLE
Fix/docktor and healthcheck fixes

### DIFF
--- a/author_decades_counter/main.py
+++ b/author_decades_counter/main.py
@@ -20,7 +20,7 @@ def main():
 
     counter = DecadeCounter(input_queues=input_queues, output_queues=output_queues, instance_id=instance_id, cluster_size=cluster_size)
     healthcheck = HealthCheck(port=healthcheck_port)
-    healthcheck_thread = threading.Thread(target=healthcheck.start)
+    healthcheck_thread = threading.Thread(target=healthcheck.start, daemon=True)
     healthcheck_thread.start()
     signal.signal(signal.SIGTERM, lambda signum, frame: [method() for method in [counter.shutdown, healthcheck.shutdown, healthcheck_thread.join]])
     logging.info("Decade counter starting")

--- a/book_filter/main.py
+++ b/book_filter/main.py
@@ -21,7 +21,7 @@ def main():
 
     book_filter = BookFilter(input_queues, output_queues, output_exchanges, instance_id, cluster_size)
     healthcheck = HealthCheck(port=healthcheck_port)
-    healthcheck_thread = threading.Thread(target=healthcheck.start)
+    healthcheck_thread = threading.Thread(target=healthcheck.start, daemon=True)
     healthcheck_thread.start()
     signal.signal(signal.SIGTERM, lambda signum, frame: [method()
                   for method in [book_filter.shutdown, healthcheck.shutdown, healthcheck_thread.join]])

--- a/docker-compose-generator/src/config_generator.py
+++ b/docker-compose-generator/src/config_generator.py
@@ -368,6 +368,7 @@ class ConfigGenerator:
                 'EXCLUDED_CONTAINERS=["rabbitmq", "book_boundary", "review_boundary", "output_boundary", "client"]',
                 "PROJECT_NAME=tp1",
                 "SLEEP_INTERVAL=0.07",
+                "KILL_PROBABILITY_PERCENTAGE=1",
             ],
             networks=["test_net"],
             volumes=["/var/run/docker.sock:/var/run/docker.sock"],

--- a/docktor/main.py
+++ b/docktor/main.py
@@ -15,6 +15,7 @@ def main():
     excluded_containers = json.loads(os.getenv("EXCLUDED_CONTAINERS")) or []
     instance_id = json.loads(os.getenv("INSTANCE_ID") or '0')
     cluster_size = json.loads(os.getenv("CLUSTER_SIZE") or '0')
+    kill_probability_percentage: int = json.loads(os.getenv("KILL_PROBABILITY_PERCENTAGE") or '1')
     sleep_interval = json.loads(os.getenv("SLEEP_INTERVAL") or '0.07')
     healthcheck_port = json.loads(os.getenv("HEALTHCHECK_PORT") or '8888')
 
@@ -26,6 +27,7 @@ def main():
                       cluster_size=cluster_size,
                       excluded_containers=excluded_containers,
                       project_name=project_name,
+                      kill_probability_percentage=kill_probability_percentage,
                       sleep_interval=sleep_interval,
                       healthcheck_port=healthcheck_port)
 

--- a/docktor/main.py
+++ b/docktor/main.py
@@ -20,7 +20,7 @@ def main():
     healthcheck_port = json.loads(os.getenv("HEALTHCHECK_PORT") or '8888')
 
     healthcheck = HealthCheck(port=healthcheck_port)
-    healthcheck_thread = threading.Thread(target=healthcheck.start)
+    healthcheck_thread = threading.Thread(target=healthcheck.start, daemon=True)
     healthcheck_thread.start()
 
     docktor = Docktor(instance_id=instance_id,

--- a/docktor/src/docktor.py
+++ b/docktor/src/docktor.py
@@ -11,6 +11,7 @@ class Docktor:
                  cluster_size: int,
                  excluded_containers: list[str],
                  project_name: str,
+                 kill_probability_percentage: int = 1,
                  sleep_interval: float = 0.07,
                  healthcheck_port: int = 8888):
         self.client = docker.from_env()
@@ -23,6 +24,7 @@ class Docktor:
             "label": f"com.docker.compose.project={project_name}"
         }
         self.sleep_interval = sleep_interval
+        self.kill_probability_percentage = kill_probability_percentage
 
     def start(self):
         logging.info("Docktor started")
@@ -34,7 +36,7 @@ class Docktor:
             network_name = container.name.split("-")[1]
             if network_name not in self.excluded_containers and not network_name == self.instance_name:
                 dice_throw = random.randint(0, 100)
-                if dice_throw == 0 and container.status == 'running':
+                if self.kill_probability_percentage > dice_throw and container.status == 'running':
                     logging.info(f"KILLING {network_name} INSTEAD OF CHECKING HEALTHCHECK")
                     container.kill()
                     continue

--- a/docktor/src/docktor.py
+++ b/docktor/src/docktor.py
@@ -3,6 +3,7 @@ import socket
 import logging
 import time
 import random
+
 SOCKET_TIMEOUT = 5
 
 
@@ -47,9 +48,14 @@ class Docktor:
                     self.client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     self.client_socket.connect((network_name, self.healthcheck_port))
                     self.client_socket.close()
-                except Exception as e:
-                    print(e)
-                    logging.error(f"Container {network_name} is down. Starting it up.")
+                except (socket.timeout, socket.error) as e:
+                    logging.error(e)
+                    logging.error(f"Container {network_name} is down. Restarting...")
+                    try:
+                        # Kill could fail if the container is not running
+                        container.kill()
+                    except Exception as e:
+                        logging.error(e)
                     container.start()
             time.sleep(self.sleep_interval)
 

--- a/docktor/src/docktor.py
+++ b/docktor/src/docktor.py
@@ -3,6 +3,7 @@ import socket
 import logging
 import time
 import random
+SOCKET_TIMEOUT = 5
 
 
 class Docktor:
@@ -25,6 +26,7 @@ class Docktor:
         }
         self.sleep_interval = sleep_interval
         self.kill_probability_percentage = kill_probability_percentage
+        socket.setdefaulttimeout(SOCKET_TIMEOUT)
 
     def start(self):
         logging.info("Docktor started")

--- a/review_filter/main.py
+++ b/review_filter/main.py
@@ -25,7 +25,7 @@ def main():
                                  instance_id, cluster_size)
     logging.info("Review filter starting")
     healthcheck = HealthCheck(port=healthcheck_port)
-    healthcheck_thread = threading.Thread(target=healthcheck.start)
+    healthcheck_thread = threading.Thread(target=healthcheck.start, daemon=True)
     healthcheck_thread.start()
     signal.signal(signal.SIGTERM, lambda signum, frame: [method()
                   for method in [review_filter.shutdown, healthcheck.shutdown, healthcheck_thread.join]])

--- a/review_mean_aggregator/main.py
+++ b/review_mean_aggregator/main.py
@@ -21,7 +21,7 @@ def main():
                                                   )
     logging.info("Review mean aggregator is starting")
     healthcheck = HealthCheck(port=healthcheck_port)
-    healthcheck_thread = threading.Thread(target=healthcheck.start)
+    healthcheck_thread = threading.Thread(target=healthcheck.start, daemon=True)
     healthcheck_thread.start()
     signal.signal(signal.SIGTERM, lambda signum, frame: [method()
                   for method in [review_mean_aggregator.shutdown, healthcheck.shutdown, healthcheck_thread.join]])

--- a/review_stats_service/main.py
+++ b/review_stats_service/main.py
@@ -27,7 +27,7 @@ def main():
                                        cluster_size)
     logging.info("Review stats service %i is starting", instance_id)
     healthcheck = HealthCheck(port=healthcheck_port)
-    healthcheck_thread = threading.Thread(target=healthcheck.start)
+    healthcheck_thread = threading.Thread(target=healthcheck.start, daemon=True)
     healthcheck_thread.start()
     signal.signal(signal.SIGTERM, lambda signum, frame: [method()
                   for method in [stats_service.shutdown, healthcheck.shutdown, healthcheck_thread.join]])

--- a/router/main.py
+++ b/router/main.py
@@ -27,7 +27,7 @@ def main():
                     n_instances)
 
     healthcheck = HealthCheck(port=healthcheck_port)
-    healthcheck_thread = threading.Thread(target=healthcheck.start)
+    healthcheck_thread = threading.Thread(target=healthcheck.start, daemon=True)
     healthcheck_thread.start()
     signal.signal(signal.SIGTERM, lambda signum, frame: [method() for method in [router.shutdown, healthcheck.shutdown, healthcheck_thread.join]])
     router.start()

--- a/sentiment_aggregator/main.py
+++ b/sentiment_aggregator/main.py
@@ -20,7 +20,7 @@ def main():
                                                output_queues)
     logging.info("Review mean aggregator is starting")
     healthcheck = HealthCheck(port=healthcheck_port)
-    healthcheck_thread = threading.Thread(target=healthcheck.start)
+    healthcheck_thread = threading.Thread(target=healthcheck.start, daemon=True)
     healthcheck_thread.start()
     signal.signal(signal.SIGTERM, lambda signum, frame: [method()
                   for method in [sentiment_aggregator.shutdown, healthcheck.shutdown, healthcheck_thread.join]])

--- a/sentiment_analyzer/main.py
+++ b/sentiment_analyzer/main.py
@@ -24,7 +24,7 @@ def main():
                                            cluster_size)
     logging.info("Review sentiment analyzer %i is starting", instance_id)
     healthcheck = HealthCheck(port=healthcheck_port)
-    healthcheck_thread = threading.Thread(target=healthcheck.start)
+    healthcheck_thread = threading.Thread(target=healthcheck.start, daemon=True)
     healthcheck_thread.start()
     signal.signal(signal.SIGTERM, lambda signum, frame: [method()
                   for method in [sentiment_analyzer.shutdown, healthcheck.shutdown, healthcheck_thread.join]])


### PR DESCRIPTION
- Added env var to Docktor to controll kill probability
- Docktor now tries to kill containers before starting them
- Added default socket timeout when Docktor does healthchecks
- Docktors now function as a ring partitioning the containers managed by each instance. 
    - Each Docktor only healthchecks the next Docktor in the ring
- Healthcheck threads now run as `daemon` so the whole program dies if the main thread dies.
 