### PR TITLE
Track when to requeue EOFs in review filter

### DIFF
--- a/review_filter/src/review_filter.py
+++ b/review_filter/src/review_filter.py
@@ -28,6 +28,7 @@ class ReviewFilter:
         self.output_exchanges = output_exchanges
         self.books: dict[int, dict[str, str]] = {}
         self.eofs: set[int] = set()
+        self.should_requeue_eof: set[int] = set()
         self.persistence_manager = PersistenceManager(
             f'../storage/review_filter_{review_input_queue[0]}_{book_input_queue[0]}_{instance_id}')
         self._init_state()
@@ -104,7 +105,17 @@ class ReviewFilter:
         self.persistence_manager.delete_keys(f"{BOOKS_KEY}_{client_id}")
         self.eofs.remove(client_id)
         self.persistence_manager.put(EOFS_KEY, json.dumps(list(self.eofs)))
+        if client_id in self.should_requeue_eof:
+            self.__remove_should_requeue_eof(client_id)
         logging.info("Filter reset for client id %s", client_id)
+
+    def __add_should_requeue_eof(self, client_id: int):
+        self.should_requeue_eof.add(client_id)
+        self.persistence_manager.put("should_requeue_eof", json.dumps(list(self.should_requeue_eof)))
+
+    def __remove_should_requeue_eof(self, client_id: int):
+        self.should_requeue_eof.remove(client_id)
+        self.persistence_manager.put("should_requeue_eof", json.dumps(list(self.should_requeue_eof)))
 
     def handle_books_eof(self, eof_packet: EOFPacket):
         logging.debug(f" [x] Received Books EOF: {eof_packet}")
@@ -121,9 +132,12 @@ class ReviewFilter:
             logging.debug(f" [x] Propagated Books EOF: {eof_packet}")
 
     def handle_reviews_eof(self, eof_packet: EOFPacket):
-        if eof_packet.client_id not in self.eofs:
-            logging.warning("Received reviews EOF before books EOF - requeuing")
+        if eof_packet.client_id not in self.eofs or eof_packet.client_id in self.should_requeue_eof:
+            logging.warning("Received reviews EOF but have to requeue it - requeuing")
+            if eof_packet.client_id in self.should_requeue_eof:
+                self.__remove_should_requeue_eof(eof_packet.client_id)
             return CallbackAction.REQUEUE
+
         if self.instance_id not in eof_packet.ack_instances:
             eof_packet.ack_instances.append(self.instance_id)
             self._reset_filter(eof_packet.client_id)
@@ -143,6 +157,8 @@ class ReviewFilter:
             # TODO: What happens if the review is requeued AFTER the EOF?
             # TODO: If the review is requeued but the EOF is already queued,
             # the review will be lost -> Eofs should be requeued if this happens
+            if review.client_id not in self.should_requeue_eof:
+                self.__add_should_requeue_eof(review.client_id)
             return CallbackAction.REQUEUE
 
         if review.book_title not in self.books.get(review.client_id, {}):
@@ -170,7 +186,12 @@ class ReviewFilter:
             for book in books:
                 book = json.loads(book)
                 self.books[client_id][book[0]] = book[1]
+
         # Load eofs
         self.eofs = set(json.loads(self.persistence_manager.get(EOFS_KEY) or '[]'))
 
-        logging.info(f"Initialized state with {self.books}, eofs: {self.eofs}")
+        # Load should_requeue_eof
+        self.should_requeue_eof = set(json.loads(self.persistence_manager.get("should_requeue_eof") or '[]'))
+
+        logging.info(
+            f"Initialized state with {self.books}, eofs: {self.eofs}, should_requeue_eof: {self.should_requeue_eof}")

--- a/review_filter/src/review_filter.py
+++ b/review_filter/src/review_filter.py
@@ -10,6 +10,7 @@ import json
 
 BOOKS_KEY = 'books'
 EOFS_KEY = 'eofs'
+REQUEUE_EOF_KEY = 'should_requeue_eof'
 
 
 class ReviewFilter:
@@ -111,11 +112,11 @@ class ReviewFilter:
 
     def __add_should_requeue_eof(self, client_id: int):
         self.should_requeue_eof.add(client_id)
-        self.persistence_manager.put("should_requeue_eof", json.dumps(list(self.should_requeue_eof)))
+        self.persistence_manager.put(REQUEUE_EOF_KEY, json.dumps(list(self.should_requeue_eof)))
 
     def __remove_should_requeue_eof(self, client_id: int):
         self.should_requeue_eof.remove(client_id)
-        self.persistence_manager.put("should_requeue_eof", json.dumps(list(self.should_requeue_eof)))
+        self.persistence_manager.put(REQUEUE_EOF_KEY, json.dumps(list(self.should_requeue_eof)))
 
     def handle_books_eof(self, eof_packet: EOFPacket):
         logging.debug(f" [x] Received Books EOF: {eof_packet}")
@@ -191,7 +192,7 @@ class ReviewFilter:
         self.eofs = set(json.loads(self.persistence_manager.get(EOFS_KEY) or '[]'))
 
         # Load should_requeue_eof
-        self.should_requeue_eof = set(json.loads(self.persistence_manager.get("should_requeue_eof") or '[]'))
+        self.should_requeue_eof = set(json.loads(self.persistence_manager.get(REQUEUE_EOF_KEY) or '[]'))
 
         logging.info(
             f"Initialized state with {self.books}, eofs: {self.eofs}, should_requeue_eof: {self.should_requeue_eof}")


### PR DESCRIPTION
Added a set (`should_requeue`) to track when it is necessary to requeue a Review EOF in the review_filter. This set is persisted in disk.

- A client id gets **added** to the set when a review is received but the client id is not in the `eofs` set. After adding the client id to the `should_requeue` set, the review gets requeued.
- A client id gets **removed** from the set when:
  - a review EOF that is not in the `eofs` set is received. After removing it from the `should_requeue` set, the review EOF is requeued.
  - a review EOF that is in the `should_requeue`set is received. After removing it from the `should_requeue` set, the review EOF is requeued.

